### PR TITLE
Allow to run the application against a given Kube config and K8S context

### DIFF
--- a/changes/24.feature
+++ b/changes/24.feature
@@ -1,0 +1,1 @@
+Allow to run the application against a given Kube config and K8S context

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ func Execute() {
 }
 
 func init() {
+	// Add flags
 	rootCmd.PersistentFlags().BoolVarP(&debugEnabled, "debug", "d", false, "Enable debug mode")
 	rootCmd.PersistentFlags().StringVarP(&loggingFile, "log", "l", "", "Enable logging")
 }


### PR DESCRIPTION
Implements https://github.com/ArmDeveloperEcosystem/kubearchinspect/issues/19

New flags are introduced to accept context using `kube-context` flag, and to accept path to Kube config using `kube-config-path`.